### PR TITLE
rudimentary map patch system

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -223,6 +223,9 @@ SUBSYSTEM_DEF(mapping)
 	// check that the total z count of all maps matches the list of traits
 	var/total_z = 0
 	var/list/parsed_maps = list()
+	//slug add
+	var/list/patch_types = list()
+	//slug end
 	for (var/file in files)
 		var/full_path = "_maps/[path]/[file]"
 		var/datum/parsed_map/pm = new(file(full_path))
@@ -231,6 +234,12 @@ SUBSYSTEM_DEF(mapping)
 			errorList |= full_path
 			continue
 		parsed_maps[pm] = total_z  // save the start Z of this file
+		//slug add
+
+		var/T = text2path(lowertext("/datum/slugstation/map_patch/[path]/[splittext(file, ".")[1]]"))
+		if (T)
+			patch_types[pm] = new T()  //get the patch type from the map name
+		//slug end
 		total_z += bounds[MAP_MAXZ] - bounds[MAP_MINZ] + 1
 
 	if (!length(traits))  // null or empty - default
@@ -255,6 +264,10 @@ SUBSYSTEM_DEF(mapping)
 		var/datum/parsed_map/pm = P
 		if (!pm.load(1, 1, start_z + parsed_maps[P], no_changeturf = TRUE))
 			errorList |= pm.original_path
+		//slug add
+		if (patch_types[P])
+			patch_types[P].PatchMap(1, 1, start_z + parsed_maps[P])
+			//slug end
 	if(!silent)
 		INIT_ANNOUNCE("Loaded [name] in [(REALTIMEOFDAY - start_time)/10]s!")
 	return parsed_maps

--- a/slugstation/code/datum/map_patch/yogstation.dm
+++ b/slugstation/code/datum/map_patch/yogstation.dm
@@ -1,0 +1,8 @@
+/datum/slugstation/map_patch
+	proc/PatchMap(var/x, var/y, var/z)
+/datum/slugstation/map_patch/map_files/yogstation/yogstation
+	PatchMap(var/x, var/y, var/z)
+		//add patches here!
+		//For instance, if you typed (don't uncomment this, that means YOU robin):
+		//new /obj/item/melee/singularity_sword(locate(20, 20, z))
+		//It'd spawn a singulo sword on the station Z level in space (at 20, 20)

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -3210,6 +3210,7 @@
 #include "interface\menu.dm"
 #include "interface\stylesheet.dm"
 #include "interface\skin.dmf"
+#include "slugstation\code\datum\map_patch\yogstation.dm"
 #include "yogstation\code\__HELPERS\_lists.dm"
 #include "yogstation\code\__HELPERS\_logging.dm"
 #include "yogstation\code\__HELPERS\game.dm"


### PR DESCRIPTION
# Document the changes in your pull request

This creates a system for patching maps. Basically, you create a type with the path:
`/datum/slugstation/map_patch/[path to the map file, relative to _maps, minus the .dmm]`
Then, just override the PatchMap method, and code in any changes you may want, including loading other maps over the original map.
Note that this only works with maps generated from LoadGroup.