### PR TITLE
THE DAY 1 GONDOLFIX

### DIFF
--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -419,6 +419,11 @@
 	var/list/limb_list = list(BODY_ZONE_HEAD, BODY_ZONE_CHEST, BODY_ZONE_R_ARM, BODY_ZONE_L_ARM, BODY_ZONE_R_LEG, BODY_ZONE_L_LEG)
 	if(excluded_limbs)
 		limb_list -= excluded_limbs
+	//slug add
+	if (dna.species.id == "gondola")
+		limb_list -= BODY_ZONE_L_ARM
+		limb_list -= BODY_ZONE_R_ARM
+	//slug end
 	for(var/Z in limb_list)
 		. += regenerate_limb(Z, noheal)
 	if(("legs" in dna?.species?.mutant_bodyparts) && dna.features["legs"] == "Digitigrade Legs")

--- a/slugstation/code/modules/mob/living/carbon/human/species_types/gondola.dm
+++ b/slugstation/code/modules/mob/living/carbon/human/species_types/gondola.dm
@@ -48,6 +48,10 @@
 	C.unignore_slowdown(type)
 	if (break_gondoloath)
 		break_gondoloath.Remove(C)
+	var/obj/item/bodypart/arm = C.newBodyPart(BODY_ZONE_L_ARM)
+	arm.species_id = new_species.limbs_id
+	arm = C.newBodyPart(BODY_ZONE_R_ARM)
+	arm.species_id = new_species.limbs_id
 	REMOVE_TRAIT(C, TRAIT_MUTE, SPECIES_TRAIT)
 	REMOVE_TRAIT(C, TRAIT_PACIFISM, SPECIES_TRAIT)
 


### PR DESCRIPTION
fixes character select's arms disappearing after selecting gondola, makes arms regenerate after becoming a non-dola, and fixes rejuvenation on gondolas